### PR TITLE
 docs/separate authors links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <!-- PROJECT SHIELDS -->
 [![Forks][forks-shield]][forks-url]
 [![Stargazers][stars-shield]][stars-url]
-[![Issues-open][issues-open-shield]](https://github.com/Israel-Laguan/arduino-relay-app/issues?q=is%3Aopen+is%3Aissue)
-[![Issues-closed][issues-closed-shield]](https://github.com/Israel-Laguan/arduino-relay-app/issues?q=is%3Aissue+is%3Aclosed)
+[![Issues-open][issues-open-shield]][issues-open-url]
+[![Issues-closed][issues-closed-shield]][issues-close-url]
 [![Contributors][contributors-shield]][contributors-url]
 [![contributions welcome][contributions-welcome]][issues-url]
 
@@ -164,6 +164,8 @@ Feel free to fork this project and improve it
 [stars-url]: https://github.com/Israel-Laguan/arduino-relay-app/stargazers
 [issues-open-shield]: https://img.shields.io/github/issues/Israel-Laguan/arduino-relay-app?style=for-the-badge
 [issues-url]: https://github.com/Israel-Laguan/arduino-relay-app/issues
+[issues-open-url]: https://github.com/Israel-Laguan/arduino-relay-app/issues?q=is%3Aopen+is%3Aissue
+[issues-close-url]: https://github.com/Israel-Laguan/arduino-relay-app/issues?q=is%3Aissue+is%3Aclosed
 [issues-closed-shield]: https://img.shields.io/github/issues-closed/Israel-Laguan/arduino-relay-app?style=for-the-badge
 [badge-framework]: https://img.shields.io/badge/framework-Next.js-000?style=for-the-badge&logo=next.js
 [framework-url]: https://google.com

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <!-- PROJECT SHIELDS -->
 [![Forks][forks-shield]][forks-url]
 [![Stargazers][stars-shield]][stars-url]
-[![Issues-open][issues-open-shield]][issues-url]
-[![Issues-closed][issues-closed-shield]][issues-url]
+[![Issues-open][issues-open-shield]](https://github.com/Israel-Laguan/arduino-relay-app/issues?q=is%3Aopen+is%3Aissue)
+[![Issues-closed][issues-closed-shield]](https://github.com/Israel-Laguan/arduino-relay-app/issues?q=is%3Aissue+is%3Aclosed)
 [![Contributors][contributors-shield]][contributors-url]
 [![contributions welcome][contributions-welcome]][issues-url]
 

--- a/README.md
+++ b/README.md
@@ -105,28 +105,29 @@ The app should now be up and running at http://localhost:3000 🚀
     <td>
         <div align="center">
             <a href="mailto:israellaguan@gmail.com" target="_blank" rel="author">
-                <img src="https://img.icons8.com/color/48/000000/message-squared.png" style="border-radius: 10%" alt="My GitHub" height="45px">
-                <h3>
-                    Email me to 
-                    <a href="mailto:israellaguan@gmail.com">
-                        israellaguan@gmail.com
-                    </a>
-                </h3>
+                <img src="https://img.icons8.com/color/48/000000/message-squared.png" alt="My GitHub" height="45px">
             </a>
+            <h3>
+                <a href="mailto:israellaguan@gmail.com" target="_blank" rel="author">
+                    Email me to israellaguan@gmail.com
+                </a>
+            </h3>
             <a href="https://www.linkedin.com/in/israellaguan/" target="_blank" rel="author">
                 <img src="https://img.icons8.com/color/48/000000/linkedin.png" alt="My Linkedin" height="45px">
-                <h3>
+            </a>
+            <h3>
+                <a href="https://www.linkedin.com/in/israellaguan/" target="_blank" rel="author">
                     Connect to my Linkedin
-                </h3>
-            </a>
+                </a>
+            </h3>
             <a href="https://github.com/Israel-Laguan" target="_blank" rel="author">
-                <img src="https://img.icons8.com/color/48/000000/github--v1.png" 
-			style="border-radius: 10%" alt="My GitHub" height="45px"
-		>
-                <h3>
-                    Check my GitHub Profile
-                </h3>
+                <img src="https://img.icons8.com/color/48/000000/github--v1.png" alt="My GitHub" height="45px">
             </a>
+            <h3>
+                <a href="https://github.com/Israel-Laguan" target="_blank" rel="author">
+                    Check my GitHub Profile
+                </a>
+            </h3>
         </div>
     </td>
   </tr>


### PR DESCRIPTION
## Description
- I just separate individuals links to show styles of anchors
- Clicking on the Open or Closed Issues label displays the correct information.

fixes [#133](https://github.com/Azordev/various-tasks/issues/133)
fixes [#146](https://github.com/Azordev/various-tasks/issues/146)
## Screenshots
![2022-05-18 13_06_28-TrayControl](https://user-images.githubusercontent.com/71513679/169101405-57d573ef-9780-446f-9a2b-51fe989b625a.png)
